### PR TITLE
Release/0.1.28

### DIFF
--- a/account-vending/account-bootstrap-shared-product/product.template.yaml
+++ b/account-vending/account-bootstrap-shared-product/product.template.yaml
@@ -113,7 +113,7 @@ Resources:
       Description: Lambda for accepting shares
       Role: !GetAtt BootstrapperProjectCustomResourceRole.Arn
       Runtime: python3.7
-      Timeout: 30
+      Timeout: 900
       Environment:
         Variables:
           BOOTSTRAPPER_PROJECT_NAME: !Ref BootstrapperProject

--- a/account-vending/account-bootstrap-shared-product/requirements.txt
+++ b/account-vending/account-bootstrap-shared-product/requirements.txt
@@ -1,1 +1,1 @@
-better-boto==0.6.14
+better-boto==0.6.16

--- a/account-vending/account-bootstrap-shared-product/src/handler.py
+++ b/account-vending/account-bootstrap-shared-product/src/handler.py
@@ -50,7 +50,7 @@ def handler(event, context):
                             'type': 'PLAINTEXT'
                         },
                     ],
-                ).get('build')
+                )
                 final_status = bootstrapper_build.get('buildStatus')
 
                 if final_status == 'SUCCEEDED':
@@ -63,7 +63,7 @@ def handler(event, context):
                                 'type': 'PLAINTEXT'
                             }
                         ],
-                    ).get('build')
+                    )
                     final_status = puppet_run_build.get('buildStatus')
 
                     if final_status == 'SUCCEEDED':

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("servicecatalog_factory/requirements.txt", "r") as fh:
 
 setuptools.setup(
     name="aws-service-catalog-factory",
-    version="0.1.26",
+    version="0.1.28",
     author="Eamonn Faherty",
     author_email="aws-service-catalog-tools@amazon.com",
     description="Making it easier to build out ServiceCatalog products",


### PR DESCRIPTION
account-vending bootstrap shared product now runs servicecatalog-puppet on the newly created account.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
