### PR TITLE
Issue/49

### DIFF
--- a/servicecatalog_factory/cli.py
+++ b/servicecatalog_factory/cli.py
@@ -175,6 +175,7 @@ def create_product(service_catalog, portfolio, product, s3_bucket_name):
         PortfolioId=portfolio.get('Id')
     )
 
+    # associate_product_with_portfolio is not a synchronous request
     LOGGER.info(f'Waiting for the product: {product.get("Name")} '
                 f'to be associated with the portfolio: {portfolio.get("Id")}')
     while True:

--- a/servicecatalog_factory/cli.py
+++ b/servicecatalog_factory/cli.py
@@ -159,10 +159,10 @@ def create_product(service_catalog, portfolio, product, s3_bucket_name):
     LOGGER.info(f"Created product: {product_id}")
 
     # create_product is not a synchronous request and describe product doesnt work here
-    LOGGER.info('Waiting for the product to register: {}'.format(product.get('Name')))
+    LOGGER.info('Waiting for the product to be created: {}'.format(product.get('Name')))
     while True:
-        response = service_catalog.search_products_as_admin_single_page(PortfolioId=portfolio.get('Id'))
         time.sleep(2)
+        response = service_catalog.search_products_as_admin_single_page()
         products_ids = [
             product_view_detail.get('ProductViewSummary').get('ProductId') for product_view_detail in response.get('ProductViewDetails')
         ]
@@ -174,6 +174,19 @@ def create_product(service_catalog, portfolio, product, s3_bucket_name):
         ProductId=product_id,
         PortfolioId=portfolio.get('Id')
     )
+
+    LOGGER.info(f'Waiting for the product: {product.get("Name")} '
+                f'to be associated with the portfolio: {portfolio.get("Id")}')
+    while True:
+        time.sleep(2)
+        response = service_catalog.search_products_as_admin_single_page(PortfolioId=portfolio.get('Id'))
+        products_ids = [
+            product_view_detail.get('ProductViewSummary').get('ProductId') for product_view_detail in response.get('ProductViewDetails')
+        ]
+        LOGGER.info(f'Looking for {product_id} in {products_ids} for {portfolio.get("Id")}')
+        if product_id in products_ids:
+            break
+
     return product_view
 
 

--- a/servicecatalog_factory/cli.py
+++ b/servicecatalog_factory/cli.py
@@ -161,7 +161,7 @@ def create_product(service_catalog, portfolio, product, s3_bucket_name):
     # create_product is not a synchronous request and describe product doesnt work here
     LOGGER.info('Waiting for the product to register: {}'.format(product.get('Name')))
     while True:
-        response = service_catalog.search_products_as_admin_single_page()
+        response = service_catalog.search_products_as_admin_single_page(PortfolioId=portfolio.get('Id'))
         time.sleep(2)
         products_ids = [
             product_view_detail.get('ProductViewSummary').get('ProductId') for product_view_detail in response.get('ProductViewDetails')

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("servicecatalog_factory/requirements.txt", "r") as fh:
 
 setuptools.setup(
     name="aws-service-catalog-factory",
-    version="0.1.37",
+    version="0.1.38",
     author="Eamonn Faherty",
     author_email="aws-service-catalog-tools@amazon.com",
     description="Making it easier to build out ServiceCatalog products",


### PR DESCRIPTION
*Issue #49*

*Description of changes:*
Boto3 service_catalog.associate_product_with_portfolio is not synchronous.  Now using search_products_as_admin with a portfolio id parameter for filtering to wait for the resultant action to be confirmed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
