### PR TITLE
Update codebuild version to aws/codebuild/standard:3.0

### DIFF
--- a/servicecatalog_factory/templates/product-cloudformation.j2
+++ b/servicecatalog_factory/templates/product-cloudformation.j2
@@ -179,7 +179,7 @@ Resources:
       Environment:
         Type: linuxContainer
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:1.0
+        Image: aws/codebuild/standard:3.0
         EnvironmentVariables:
           - Name: STACK_NAME
             Type: PLAINTEXT
@@ -232,7 +232,7 @@ Resources:
       Environment:
         Type: linuxContainer
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:1.0
+        Image: aws/codebuild/standard:3.0
         EnvironmentVariables:
           - Name: STACK_NAME
             Type: PLAINTEXT

--- a/servicecatalog_factory/templates/product-terraform.j2
+++ b/servicecatalog_factory/templates/product-terraform.j2
@@ -157,7 +157,7 @@ Resources:
       Environment:
         Type: linuxContainer
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:1.0
+        Image: aws/codebuild/standard:3.0
         EnvironmentVariables:
           - Name: STACK_NAME
             Type: PLAINTEXT


### PR DESCRIPTION
Fixes #115 

Updated codebuild container image to standard:3.0.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
