### PR TITLE
Codebuild container

### DIFF
--- a/docs/source/factory/building_your_pipelines.rst
+++ b/docs/source/factory/building_your_pipelines.rst
@@ -255,6 +255,19 @@ in the context:
 
 If you do decide to override the default build spec please ensure you capture the artifacts needed for the deploy stage.
 
+The default image used for the Package stage of the pipeline is ```aws/codebuild/standard:4.0```.
+To choose the image, add a BuildSpecImage configuration to either the product or version.
+
+.. code-block:: yaml
+
+        Versions:
+          - Name: v1
+            Description: MVP for iam development account.
+            BuildSpecImage: aws/codebuild/standard:4.0
+            BuildSpec: |
+              mybuildspec...
+
+
 Deploy
 ------
 

--- a/servicecatalog_factory/schema.yaml
+++ b/servicecatalog_factory/schema.yaml
@@ -27,6 +27,8 @@ schema;map_component:
     SupportUrl:
       type: str
       pattern: https?://(?:[-\w.]|(?:%[\da-fA-F]{2}))+
+    BuildSpecImage:
+      type: str
     BuildSpec:
       type: str
     Source:
@@ -81,6 +83,8 @@ schema;map_component:
                   type: bool
                 ShouldCloudformationRSpec:
                   type: bool
+            BuildSpecImage:
+              type: str
             BuildSpec:
               type: str
             Source:

--- a/servicecatalog_factory/templates/product-cloudformation.j2
+++ b/servicecatalog_factory/templates/product-cloudformation.j2
@@ -235,7 +235,15 @@ Resources:
       Environment:
         Type: linuxContainer
         ComputeType: BUILD_GENERAL1_SMALL
+        {% if version.BuildSpecImage %}
+        Image: {{ version.BuildSpecImage }}
+        {% else %}
+        {% if product.BuildSpecImage %}
+        Image: {{ product.BuildSpecImage }}
+        {% else %}
         Image: aws/codebuild/standard:4.0
+        {% endif %}
+        {% endif %}
         EnvironmentVariables:
           - Name: STACK_NAME
             Type: PLAINTEXT

--- a/servicecatalog_factory/templates/product-cloudformation.j2
+++ b/servicecatalog_factory/templates/product-cloudformation.j2
@@ -179,7 +179,7 @@ Resources:
       Environment:
         Type: linuxContainer
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:3.0
+        Image: aws/codebuild/standard:4.0
         EnvironmentVariables:
           - Name: STACK_NAME
             Type: PLAINTEXT
@@ -235,7 +235,7 @@ Resources:
       Environment:
         Type: linuxContainer
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:3.0
+        Image: aws/codebuild/standard:4.0
         EnvironmentVariables:
           - Name: STACK_NAME
             Type: PLAINTEXT

--- a/servicecatalog_factory/templates/product-terraform.j2
+++ b/servicecatalog_factory/templates/product-terraform.j2
@@ -157,7 +157,7 @@ Resources:
       Environment:
         Type: linuxContainer
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:3.0
+        Image: aws/codebuild/standard:4.0
         EnvironmentVariables:
           - Name: STACK_NAME
             Type: PLAINTEXT


### PR DESCRIPTION
Update standard CodeBuild container to standard:4.0 as it supports python3.7, which was dropped from standard:3.0

Add option to specify CodeBuild container for Cloudformation Package stage of pipeline.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
