### PR TITLE
Allow associations and tags to not be defined.

### DIFF
--- a/servicecatalog_factory/core.py
+++ b/servicecatalog_factory/core.py
@@ -156,7 +156,7 @@ def generate_via_luigi(p, branch_override=None):
                         "display_name": portfolio.get('DisplayName'),
                         "description": portfolio.get('Description'),
                         "provider_name": portfolio.get('ProviderName'),
-                        "tags": portfolio.get('Tags'),
+                        "tags": portfolio.get('Tags', []),
                     }
                     create_portfolio_task = luigi_tasks_and_targets.CreatePortfolioTask(
                         **create_portfolio_task_args
@@ -164,7 +164,7 @@ def generate_via_luigi(p, branch_override=None):
                     all_tasks[f"portfolio_{p_name}_{portfolio.get('DisplayName')}-{region}"] = create_portfolio_task
                     create_portfolio_association_task = luigi_tasks_and_targets.CreatePortfolioAssociationTask(
                         **create_portfolio_task_args,
-                        associations=portfolio.get('Associations'),
+                        associations=portfolio.get('Associations', []),
                         factory_version=factory_version,
                     )
                     all_tasks[
@@ -204,7 +204,7 @@ def generate_via_luigi(p, branch_override=None):
                             "support_description": product.get('SupportDescription'),
                             "support_email": product.get('SupportEmail'),
                             "support_url": product.get('SupportUrl'),
-                            "tags": product.get('Tags'),
+                            "tags": product.get('Tags', []),
                             "uid": "-".join([
                                 create_portfolio_task_args.get('portfolio_group_name'),
                                 create_portfolio_task_args.get('display_name'),
@@ -270,7 +270,7 @@ def generate_via_luigi(p, branch_override=None):
                         "support_description": product.get('SupportDescription'),
                         "support_email": product.get('SupportEmail'),
                         "support_url": product.get('SupportUrl'),
-                        "tags": product.get('Tags'),
+                        "tags": product.get('Tags', []),
                         "uid": product.get('Name'),
                     }
                     products_by_region[product_uid][region] = create_product_task_args

--- a/servicecatalog_factory/templates/associations.j2
+++ b/servicecatalog_factory/templates/associations.j2
@@ -2,7 +2,15 @@ AWSTemplateFormatVersion: '2010-09-09'
 Description: |
     Associations for {{portfolio.DisplayName}}
     {"version": "{{ FACTORY_VERSION }}", "framework": "servicecatalog-factory", "role": "portfolio-associations"}
+
+Conditions:
+  ShouldDoAnything: !Equals [ true, false]
+
 Resources:
+  NoOp:
+    Type: AWS::S3::Bucket
+    Condition: ShouldDoAnything
+
 {% for association in portfolio.Associations %}
   Association{{ loop.index }}:
     Type: AWS::ServiceCatalog::PortfolioPrincipalAssociation


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

When not defining `Associations` or `Tags`, the factory fails with:
```
Traceback (most recent call last):

  File "/home/rob/python/venv_service_catalog_puppet/lib/python3.8/site-packages/luigi/worker.py", line 199, in run
    new_deps = self._run_get_new_deps()

  File "/home/rob/python/venv_service_catalog_puppet/lib/python3.8/site-packages/luigi/worker.py", line 139, in _run_get_new_deps
    task_gen = self.task.run()

  File "/home/rob/python/venv_service_catalog_puppet/lib/python3.8/site-packages/servicecatalog_factory/luigi_tasks_and_targets.py", line 234, in run
    for t in self.tags:

TypeError: 'NoneType' object is not iterable
```

This is due to not defining a default in the `get()` function of the dictionary, causing it to default to `None`. Setting the default to `[]` makes it continue without errors.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
