### PR TITLE
Fix invalid Source Provider condtion

### DIFF
--- a/servicecatalog_factory/servicecatalog-factory.template.yaml
+++ b/servicecatalog_factory/servicecatalog-factory.template.yaml
@@ -300,7 +300,7 @@ Resources:
               OutputArtifacts:
                 - Name: Source
               RunOrder: 1
-              {% if Source.Provider.lower() == 'aws' %}RoleArn: !GetAtt SourceRole.Arn{% endif %}
+              {% if Source.Provider.lower() == 'codecommit' %}RoleArn: !GetAtt SourceRole.Arn{% endif %}
         - Name: Build
           Actions:
             - Name: Build


### PR DESCRIPTION
Replace "aws" with "codecommit" as AWS is not a valid source provider, and this logic prevents the role being added for CodeCommit users, in turn disabling automatic triggering on code push

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
