### PR TITLE
Updated S3 URL used for create_product and Python versions for buildspec

### DIFF
--- a/servicecatalog_factory/constants.py
+++ b/servicecatalog_factory/constants.py
@@ -62,7 +62,7 @@ PACKAGE_BUILD_SPEC_DEFAULT = """
       phases:
         install:
           runtime-versions:
-            python: 3.x
+            python: 3.7
         build:
           commands:
           {% for region in ALL_REGIONS %}

--- a/servicecatalog_factory/luigi_tasks_and_targets.py
+++ b/servicecatalog_factory/luigi_tasks_and_targets.py
@@ -238,8 +238,8 @@ class CreateProductTask(FactoryTask):
                     "Type": "CLOUD_FORMATION_TEMPLATE",
                     "Description": "Placeholder version, do not provision",
                     "Info": {
-                        "LoadTemplateFromURL": "https://s3.amazonaws.com/{}/{}".format(
-                            s3_bucket_name, "empty.template.yaml"
+                        "LoadTemplateFromURL": "https://{}.s3.{}.amazonaws.com/{}".format(
+                            s3_bucket_name, self.region, "empty.template.yaml"
                         )
                     },
                 },

--- a/servicecatalog_factory/servicecatalog-factory.template.yaml
+++ b/servicecatalog_factory/servicecatalog-factory.template.yaml
@@ -97,7 +97,7 @@ Resources:
           phases:
             install:
               runtime-versions:
-                python: 3.x
+                python: 3.7
               commands:
   {% if 'http' in VERSION %}
                 - pip install {{ VERSION }}
@@ -137,7 +137,7 @@ Resources:
           phases:
             install:
               runtime-versions:
-                python: 3.x
+                python: 3.7
               commands:
   {% if 'http' in VERSION %}
                 - pip install {{ VERSION }}


### PR DESCRIPTION
Updated S3 URL to follow virtual-hosted-style access
Updated Python versions to 3.7 from 3.x

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
