### PR TITLE
Buildspec is coming as string that can be passed to Troposphere, no n…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [tool.poetry]
 name = "aws-service-catalog-factory"
-version = "0.66.3"
+version = "0.66.4"
 description = "Making it easier to build ServiceCatalog products"
 classifiers = ["Development Status :: 5 - Production/Stable", "Intended Audience :: Developers", "Programming Language :: Python :: 3", "License :: OSI Approved :: Apache Software License", "Operating System :: OS Independent", "Natural Language :: English"]
 homepage = "https://service-catalog-tools-workshop.com/"

--- a/servicecatalog_factory/template_builder/builders.py
+++ b/servicecatalog_factory/template_builder/builders.py
@@ -545,9 +545,7 @@ class StackTemplateBuilder(BaseTemplateBuilder):
                         ],
                     ),
                     Source=codebuild.Source(
-                        BuildSpec=yaml.safe_dump(
-                            stages.get("Build", {}).get("BuildSpec")
-                        ),
+                        BuildSpec=stages.get("Build", {}).get("BuildSpec"),
                         Type="CODEPIPELINE",
                     ),
                     Description=t.Sub("build project"),

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ entry_points = \
 
 setup_kwargs = {
     'name': 'aws-service-catalog-factory',
-    'version': '0.66.3',
+    'version': '0.66.4',
     'description': 'Making it easier to build ServiceCatalog products',
     'long_description': '# aws-service-catalog-factory\n\n![logo](./docs/logo.png) \n\n## What is it?\nThis is a python3 framework that makes it easier to build multi region AWS Service Catalog portfolios.\n\nWith this framework you define a portfolio in YAML.  For each product version in your portfolio you specify which git \nrepository it is in and the framework will build out AWS CodePipelines for each product version.\n\nThese CodePipelines can run CFN_NAG and Cloudformation_rspec on your templates enabling you to check your templates are \ngood quality that they are functionally correct.\n\n## Getting started\n\nYou can read the [installation how to](https://service-catalog-tools-workshop.com/30-how-tos/10-installation/20-service-catalog-factory.html)\nor you can read through the [every day use](https://service-catalog-tools-workshop.com/30-how-tos/50-every-day-use.html)\nguides.\n\nYou can read the [documentation](https://aws-service-catalog-factory.readthedocs.io/en/latest/) to understand the inner \nworkings. \n\n\n## Going further\n\nThe framework is one of a pair.  The other is [aws-service-catalog-puppet](https://github.com/awslabs/aws-service-catalog-puppet).\nWith Service Catalog Puppet you can provision products into multiple regions of multiple accounts using YAML and you can \nshare portfolios across multiple regions of multiple accounts. \n\n## License\n\nThis library is licensed under the Apache 2.0 License. \n',
     'author': 'Eamonn Faherty',


### PR DESCRIPTION
Previously in hotfix, it was ommited Buildspec fix.

in case we define buildbuildspec in factory for stack eg :

```yaml
  Stages:
          Build:
            BuildSpecImage: aws/codebuild/standard:5.0
            BuildSpec: |
              version: 0.2
              env: 
                variables:
                  # For J2 Rendering differs in every Factory Manfiest
                  organization: RBI
                  # For J2 Rendering differs in every Factory Manfiest
                  environment: DEV
              phases:
                install:
                  runtime-versions:
                    python: 3.8
                  commands:
                    - env
                    - pip3 install j2cli
                build:
                  commands:
                    - ls -al .
                    - cat stack.template.yaml.j2
                    # Careful - this is valid for Stack , this will differ for Product / portfolio depending on Naming Convention from SC Tools.
                    - j2 stack.template.yaml.j2 -e organization -e environment -o  stack.template.yaml 
              artifacts:
                files:
                  - '*'
                  - '**/*'
```

Once Stack generic version pipeline is created, buildspec is escaped string  which can not be processed by Codebuild. Hence since it is string, no need for yaml.safe_dump

Otherwise if yaml.safe_dump remains, Codebuild build details will be
```yaml
"version: 0.2\nenv: \n  variables:\n    # For J2 Rendering differs in every Factory\
  \ Manfiest\n    organization: RBI\n    # For J2 Rendering differs in every Factory\
  \ Manfiest\n    environment: DEV\nphases:\n  install:\n    runtime-versions:\n \
  \     python: 3.8\n    commands:\n      - env\n      - pip3 install j2cli\n  build:\n\
  \    commands:\n      - ls -al .\n      - cat stack.template.yaml.j2\n      # Careful\
  \ - this is valid for Stack , this will differ for Product / portfolio depending\
  \ on Naming Convention from SC Tools.\n      - j2 stack.template.yaml.j2 -e organization\
  \ -e environment -o  stack.template.yaml \nartifacts:\n  files:\n    - '*'\n   \
  \ - '**/*'\n"
```

*Issue #, if available:*

*Description of changes:*

removing yaml.safe_dump buildspec is loaded as string for Troposphere

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
