### PR TITLE
Update show_pipelines.py

### DIFF
--- a/servicecatalog_factory/commands/show_pipelines.py
+++ b/servicecatalog_factory/commands/show_pipelines.py
@@ -2,6 +2,7 @@
 #  SPDX-License-Identifier: Apache-2.0
 import datetime
 import json
+import logging
 import os
 
 import click
@@ -60,14 +61,20 @@ def show_pipelines(p, format):
                         )
                         for product in nested_products:
                             for version in product.get("Versions", []):
-                                pipeline_name = f"{p_name}-{portfolio.get('DisplayName')}-{product.get('Name')}-{version.get('Name')}-pipeline"
-                                pipelines_to_check["portfolios"][pipeline_name] = dict()
+                                if 'Status' in version.keys() and version['Status'] == 'Terminated':
+                                    logging.info('Excluding terminated product from pipeline lookup')
+                                else:
+                                    pipeline_name = f"{p_name}-{portfolio.get('DisplayName')}-{product.get('Name')}-{version.get('Name')}-pipeline"
+                                    pipelines_to_check["portfolios"][pipeline_name] = dict()
                     for product in portfolios.get("Products", []):
                         for version in product.get("Versions", []):
-                            pipeline_name = (
-                                f"{product.get('Name')}-{version.get('Name')}-pipeline"
-                            )
-                            pipelines_to_check["portfolios"][pipeline_name] = dict()
+                            if 'Status' in version.keys() and version['Status'] == 'Terminated':
+                                logging.info('Excluding terminated product from pipeline lookup')
+                            else:
+                                pipeline_name = (
+                                    f"{product.get('Name')}-{version.get('Name')}-pipeline"
+                                )
+                                pipelines_to_check["portfolios"][pipeline_name] = dict()
 
     fake_date = datetime.datetime.now()
     with betterboto_client.ClientContextManager("codepipeline") as codepipeline:


### PR DESCRIPTION
Adding logic for portfolios to exclude terminated factory products

Description of changes: At present when running list_pipelines we see errors if the product has been terminated but left in the factory portfolio file- the following error occurs:

The account with AWS account ID 'xxxxxxxxxxxx' does not include a pipeline named 'portfolio-product-v1-pipeline'

The update amends the logic slightly so that for portfolios we are not going to lookup an SC Factory pipeline if the status of the product is terminated


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
