### PR TITLE
Updated CDKSupportCDKToolkitStackName parameter to cope with cdk bootstrap's default stack name

### DIFF
--- a/servicecatalog_factory/template_builder/cdk/product_template.py
+++ b/servicecatalog_factory/template_builder/cdk/product_template.py
@@ -39,7 +39,7 @@ def create_cdk_pipeline(
     )
     template.add_parameter(
         t.Parameter(
-            "CDKSupportCDKToolkitStackName", Type="String", Default="CDKToolKit"
+            "CDKSupportCDKToolkitStackName", Type="String", Default="CDKToolkit"
         )
     )
     template.add_parameter(


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Updated CDKSupportCDKToolkitStackName parameter to cope with cdk bootstrap's default stack name

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
