### PR TITLE
Fix pipeline template building ignoring custom BuildSpec

### DIFF
--- a/servicecatalog_factory/template_builder/pipeline_template_builder.py
+++ b/servicecatalog_factory/template_builder/pipeline_template_builder.py
@@ -950,7 +950,7 @@ class PackageTemplateMixin:
                 }
 
     def generate_package_stage_for_cloudformation(
-        self, tpl, item, versions, stages, options, input_artifact_name
+        self, tpl, item, versions, options, stages, input_artifact_name
     ):
         all_regions = config.get_regions()
         package_stage = stages.get("Package", {})
@@ -987,6 +987,7 @@ class PackageTemplateMixin:
             package_build_spec = jinja2.Template(package_build_spec).render(
                 ALL_REGIONS=all_regions
             )
+            package_build_spec = yaml.safe_load(package_build_spec)
         else:
             package_build_spec = self.generate_build_spec(
                 item, versions, all_regions, secondary_artifacts, options


### PR DESCRIPTION
The current version (0.87.1) ignores a custom BuildSpec definition like in the example below. This PR fixes the issue

```
Schema: factory-2019-04-01
Stacks:
  - Name: account-vending-prereqs-puppet-account
    Tags:
      - Key: category
        Value: foundational
      - Key: product-type
        Value: governance
    Versions:
      - Name: v1
        Active: True
        Source:
          Provider: CodeCommit
          Path: stacks/prereqs-puppet-account/v1
          Configuration:
            RepositoryName: saas_lz_account_vending
            BranchName: main
        Stages:
          Package:
            BuildSpec: |
              version: 0.2
              phases:
                install:
                  runtime-versions:
                    python: 3.x
                build:
                  commands:
                    - cd $SOURCE_PATH
                    - pip install -r requirements.txt -t src/AccountCreationCustomResourceBacker
                  {% for region in ALL_REGIONS %}
                    - aws cloudformation package --template $(pwd)/stack.template.yaml --s3-bucket sc-factory-artifacts-${ACCOUNT_ID}-{{ region }} --s3-prefix ${STACK_NAME} --output-template-file stack.template-{{ region }}.yaml
                  {% endfor %}
              artifacts:
                files:
                  - '*'
                  - '**/*'
  ```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.