### PR TITLE
Skip creation of product if already present within another portfolio

### DIFF
--- a/servicecatalog_factory/commands/task_reference.py
+++ b/servicecatalog_factory/commands/task_reference.py
@@ -308,9 +308,8 @@ def generate_tasks_for_portfolios(
                         f"create-product-{product.get('Name')}-{region}"
                     )
                     if task_reference.get(create_product_task_ref):
-                        raise Exception(
-                            f"Product {product.get('Name')} defined within {portfolio_name} {file_name} has already been declared"
-                        )
+                        self.info(f"Skipping product {product.get('Name')} defined within {portfolio_name} {file_name} as has already been declared")
+                        continue
 
                     # CREATE PRODUCT
                     task_reference[create_product_task_ref] = dict(


### PR DESCRIPTION
*Issue #, if available:*
Fixes #337 

*Description of changes:*
Change from throwing an exception when the task reference / product is already staged to be created, to logging a message and skipping.

This is an attempt to replicate the previous functionality that is present < 0.88.0 - details on the configuration to hit this is in the issue #337

I'm struggling to test this for real - getting `ImportError: cannot import name 'soft_unicode' from 'markupsafe'` (using the latest initialiser template) - weirdly 0.100.0 works fine, so am wondering if there's some weirdness / different dependency versions being pulled when installed via git vs from pypi :shrug:

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
